### PR TITLE
Fix default cache name

### DIFF
--- a/src/functions/cache.php
+++ b/src/functions/cache.php
@@ -16,12 +16,12 @@ function cache_get($cid, $bin = 'default')
     return _cache_get_object($bin)->get($cid);
 }
 
-function cache_get_multiple(array &$cids, $bin = 'cache')
+function cache_get_multiple(array &$cids, $bin = 'default')
 {
     return _cache_get_object($bin)->getMultiple($cids);
 }
 
-function cache_set($cid, $data, $bin = 'cache', $expire = CACHE_PERMANENT)
+function cache_set($cid, $data, $bin = 'default', $expire = CACHE_PERMANENT)
 {
     return _cache_get_object($bin)->set($cid, $data, $expire);
 }


### PR DESCRIPTION
The default bin is incorrectly set on a couple of the cache functions.