### PR TITLE
Fix library attachments

### DIFF
--- a/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
+++ b/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
@@ -21,10 +21,9 @@ final class RetrofitHtmlResponseAttachmentsProcessor implements AttachmentsRespo
         if (isset($attachments['library']) && is_array($attachments['library'])) {
             foreach ($attachments['library'] as $key => $item) {
                 if (is_array($item)) {
-                    $item = array_combine(['module', 'name'], $item);
-                    $item['module'] = match ($item['module']) {
+                    $item[0] = match ($item[0]) {
                         'drupal.ajax', 'jquery' => 'core',
-                        default => $item['module'],
+                        default => $item[0],
                     };
                     $attachments['library'][$key] = implode('/', $item);
                 }

--- a/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
+++ b/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
@@ -18,6 +18,18 @@ final class RetrofitHtmlResponseAttachmentsProcessor implements AttachmentsRespo
     public function processAttachments(AttachmentsInterface $response)
     {
         $attachments = $response->getAttachments();
+        if (isset($attachments['library']) && is_array($attachments['library'])) {
+            foreach ($attachments['library'] as $key => $item) {
+                if (is_array($item)) {
+                    $item = array_combine(['module', 'name'], $item);
+                    $item['module'] = match ($item['module']) {
+                        'drupal.ajax', 'jquery' => 'core',
+                        default => $item['module'],
+                    };
+                    $attachments['library'][$key] = implode('/', $item);
+                }
+            }
+        }
         if (isset($attachments['js']) && is_array($attachments['js'])) {
             foreach ($attachments['js'] as $key => $item) {
                 if (isset($item['type'], $item['data']) && $item['type'] === 'setting') {

--- a/tests/src/Unit/Render/RetrofitHtmlResponseAttachmentsProcessorTest.php
+++ b/tests/src/Unit/Render/RetrofitHtmlResponseAttachmentsProcessorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Retrofit\Drupal\Tests\Unit\Render;
+
+use Drupal\Core\Render\AttachmentsResponseProcessorInterface;
+use Drupal\Core\Render\HtmlResponse;
+use PHPUnit\Framework\TestCase;
+use Retrofit\Drupal\Render\RetrofitHtmlResponseAttachmentsProcessor;
+
+/**
+ * @coversDefaultClass \Retrofit\Drupal\Render\RetrofitHtmlResponseAttachmentsProcessor
+ */
+final class RetrofitHtmlResponseAttachmentsProcessorTest extends TestCase
+{
+    /**
+     * @covers ::processAttachments
+     */
+    public function testProcessAttachments(): void
+    {
+        $response = new HtmlResponse('');
+        $response->setAttachments([
+            'library' => [
+                ['foo', 'bar']
+            ],
+        ]);
+        $inner = $this->createMock(AttachmentsResponseProcessorInterface::class);
+        $inner->expects(self::once())
+            ->method('processAttachments')
+            ->with($response);
+        $sut = new RetrofitHtmlResponseAttachmentsProcessor($inner);
+        $sut->processAttachments($response);
+        self::assertEquals(
+            [
+                'library' => [
+                    'foo/bar'
+                ],
+            ],
+            $response->getAttachments()
+        );
+    }
+}


### PR DESCRIPTION
Libraries in Drupal 7 are attached as an array:
```
$return['#attached']['library'][] = array(
  $library['module'], $library['name'],
);
```
Whereas in Drupal 10 they are attached as a string with a slash separating the module and library name:
```
$return['#attached']['library'][] = $library['module'] . '/' . $library['name'];
```