### PR TITLE
Add missing form functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -856,7 +856,7 @@ parameters:
 			path: src/functions/file.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
+			message: "#^Call to an undefined method object\\:\\:setFormId\\(\\)\\.$#"
 			count: 2
 			path: src/functions/form.php
 
@@ -866,22 +866,17 @@ parameters:
 			path: src/functions/form.php
 
 		-
-			message: "#^Function form_set_error\\(\\) has no return type specified\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, 'strval' given\\.$#"
 			count: 1
 			path: src/functions/form.php
 
 		-
-			message: "#^Function form_set_error\\(\\) has parameter \\$limit_validation_errors with no type specified\\.$#"
+			message: "#^Parameter \\#1 \\$form_arg of method Drupal\\\\Core\\\\Form\\\\FormBuilderInterface\\:\\:buildForm\\(\\) expects Drupal\\\\Core\\\\Form\\\\FormInterface\\|string, object given\\.$#"
 			count: 1
 			path: src/functions/form.php
 
 		-
-			message: "#^Function form_set_error\\(\\) has parameter \\$message with no type specified\\.$#"
-			count: 1
-			path: src/functions/form.php
-
-		-
-			message: "#^Function form_set_error\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Parameter \\#1 \\$form_arg of method Drupal\\\\Core\\\\Form\\\\FormBuilderInterface\\:\\:getForm\\(\\) expects Drupal\\\\Core\\\\Form\\\\FormInterface\\|string, object given\\.$#"
 			count: 1
 			path: src/functions/form.php
 

--- a/src/functions/form.php
+++ b/src/functions/form.php
@@ -2,19 +2,80 @@
 
 declare(strict_types=1);
 
-function form_set_error($name = null, $message = '', $limit_validation_errors = null)
+use Drupal\Core\Form\FormStateInterface;
+use Retrofit\Drupal\Form\DrupalGetForm;
+use Retrofit\Drupal\Form\ArrayAccessFormState;
+
+/**
+ * @param mixed[] $form_state
+ * @return mixed[]
+ */
+function drupal_build_form(string $form_id, array &$form_state): array
 {
-    $form = &drupal_static(__FUNCTION__, array());
+    $form_object = \Drupal::classResolver(DrupalGetForm::class);
+    $form_object->setFormId($form_id);
+    $original_form_state = $form_state;
+    $form_state = new ArrayAccessFormState();
+    foreach ($original_form_state as $offset => $value) {
+        $form_state[$offset] = $value;
+    }
+    return \Drupal::formBuilder()->buildForm($form_object, $form_state);
+}
+
+function drupal_form_submit(string $form_id, FormStateInterface $form_state): void
+{
+    \Drupal::formBuilder()->submitForm($form_id, $form_state);
+}
+
+/**
+ * @return mixed[]
+ */
+function drupal_get_form(string $form_id): array
+{
+    $form_object = \Drupal::classResolver(DrupalGetForm::class);
+    $form_object->setFormId($form_id);
+    return \Drupal::formBuilder()->getForm($form_object);
+}
+
+/**
+ * @param mixed[] $element
+ */
+function form_error(array &$element, string $message = ''): void
+{
+    form_set_error(implode('][', (array) $element['#parents']), $message);
+}
+
+function form_load_include(
+    FormStateInterface &$form_state,
+    string $type,
+    string $module,
+    ?string $name = null
+): string|false {
+    return $form_state->loadInclude($module, $type, $name);
+}
+
+/**
+ * @param ?string[] $limit_validation_errors
+ * @return mixed[]
+ */
+function form_set_error(?string $name = null, string $message = '', ?array $limit_validation_errors = null): array
+{
+    // @todo Find a way to get form state to this really works.
+    $form = &drupal_static(__FUNCTION__, []);
+    $form = (array) $form;
     $sections = &drupal_static(__FUNCTION__ . ':limit_validation_errors');
     if (isset($limit_validation_errors)) {
         $sections = $limit_validation_errors;
     }
     if (isset($name) && !isset($form[$name])) {
         $record = true;
-        if (isset($sections)) {
+        if (is_array($sections)) {
             $record = false;
             foreach ($sections as $section) {
-                if (array_slice(explode('][', $name), 0, count($section)) === array_map('strval', $section)) {
+                if (
+                    array_slice(explode('][', $name), 0, count((array) $section))
+                    === array_map('strval', (array) $section)
+                ) {
                     $record = true;
                     break;
                 }
@@ -24,8 +85,20 @@ function form_set_error($name = null, $message = '', $limit_validation_errors = 
             $form[$name] = $message;
         }
     }
-
     return $form;
+}
+
+/**
+ * @param mixed[] $element
+ */
+function form_set_value(array $element, mixed $value, FormStateInterface &$form_state): void
+{
+    $form_state->setValueForElement($element, $value);
+}
+
+function form_state_values_clean(FormStateInterface $form_state): void
+{
+    $form_state->cleanValues();
 }
 
 function form_get_errors()


### PR DESCRIPTION
In D10 form errors are set on form state, so some of these functions are placeholders to prevent crashes until we find a way to access form state.