### PR TITLE
Renderer may return string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1046,6 +1046,11 @@ parameters:
 			path: src/functions/taxonomy.php
 
 		-
+			message: "#^Function theme\\(\\) never returns string so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/functions/theme.php
+
+		-
 			message: "#^Call to an undefined method object\\:\\:createInstance\\(\\)\\.$#"
 			count: 1
 			path: tests/src/Integration/Block/BlockTest.php

--- a/src/functions/theme.php
+++ b/src/functions/theme.php
@@ -8,7 +8,7 @@ use Drupal\Core\Render\RendererInterface;
 /**
  * @param array<string, mixed> $variables
  */
-function theme(string $hook, array $variables = []): MarkupInterface
+function theme(string $hook, array $variables = []): MarkupInterface|string
 {
     $build['#theme'] = $hook;
     foreach ($variables as $key => $variable) {


### PR DESCRIPTION
`\Drupal\Core\Render\Renderer::doRender` may return a `string` although `render` should always be Markup.

From https://github.com/retrofit-drupal/retrofit/pull/63
